### PR TITLE
navigation bar renders at the top of the giffygram page. the logout b…

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -1,10 +1,11 @@
 import { PostList } from "./feed/PostList.js"
+import { NavBar } from "./nav/NavBar.js"
 
 export const GiffyGram = () => {
 
     // Show main main UI
     return `
-    <h1>Giffygram</h1>
+    ${NavBar()}
     ${PostList()}
     `
 }

--- a/src/scripts/nav/NavBar.js
+++ b/src/scripts/nav/NavBar.js
@@ -1,0 +1,36 @@
+
+
+export const NavBar = () => {
+    return `
+    <nav class="navigation">
+
+    <div class="navigation__item navigation__icon">
+        <img src="../images/pb.png" alt="Giffygram icons" id="logo">
+    </div>
+    
+    <div class"navigation__item navigation__name">Giffygram</div>
+    <div class="navigation__item navigation__search"></div>
+
+    <div class="navigator__item navigation__message">
+        <img id="directMessageIcon" src="../images/fountain-pen.svg" alt+'Direct message">
+        <div class="notification__count">0</div>
+    </div>
+
+    <div class="nagivator__item navigation__logout">
+        <button id="logout" class="fakeLink">Logout</button>
+    </div>
+    </nav>
+    `
+}
+
+
+const mainContainer = document.querySelector(".giffygram")
+
+mainContainer.addEventListener("click", clickEvent => {
+    if (clickEvent.target.id === "logout") {
+
+        localStorage.setItem("gg_user", null)
+        mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+
+    }
+})

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -18,7 +18,7 @@
 }
 
 .navigation__name {
-    font-size: 1.5rem;
+    font-size: 2rem;
     padding-left: 0.5rem;
     padding-top: 0.1rem;
 }
@@ -63,4 +63,8 @@
 
 #directMessageIcon {
     cursor: pointer;
+}
+
+div {
+    display: block;
 }


### PR DESCRIPTION
navigation bar renders at the top of the giffygram page. the logout button is currently the only element with an event listener

#### Changes Made
1.  Nav Bar now renders at the top of the giffygram page. the logout element has an event listener that will logout the user and re-render the login page
​
#### Related Issue(s)
Fixes #40

#### Steps to Review
1. provided the user is on the giffygram page, all elements in the nav bar should be visisble.
2. When the user clicks on the logout element the page should be re-rendered to the login page.
