### PR TITLE
added event listener to favorite a post

### DIFF
--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -24,11 +24,11 @@ const PostBuilder = (postObj) => {
     const likes = getLikes()
     const foundLike = likes.find(
         (likeObj) => {
-            return (likeObj.postId === postObj.id)
+            return (likeObj.postId === postObj.id && likeObj.userId === parseInt(localStorage.getItem("gg_user")))
         }
     )
 
-    if (foundLike && foundLike.userId === parseInt(localStorage.getItem("gg_user"))) {
+    if (foundLike) {
         html += `<div class="star-icon"><img id="favoritePost--${postObj.id}" class="actionIcon" src="../images/favorite-star-yellow.svg"></div>`
     } else {
         html += `<div class="star-icon"><img id="favoritePost--${postObj.id}" class="actionIcon" src="../images/favorite-star-blank.svg"></div>`
@@ -74,13 +74,13 @@ mainContainer.addEventListener("click", clickEvent => {
             }
         )
 
-        if (foundLike) {
+        if (foundLike && foundLike.userId === parseInt(localStorage.getItem("gg_user"))) {
             deleteLike(foundLike.id)
 
         } else {
             
             const likeObj = {
-                userId: foundPost.userId,
+                userId: parseInt(localStorage.getItem("gg_user")),
                 postId: parseInt(postId)
             }
     

--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -28,7 +28,7 @@ const PostBuilder = (postObj) => {
         }
     )
 
-    if (foundLike) {
+    if (foundLike && foundLike.userId === parseInt(localStorage.getItem("gg_user"))) {
         html += `<div class="star-icon"><img id="favoritePost--${postObj.id}" class="actionIcon" src="../images/favorite-star-yellow.svg"></div>`
     } else {
         html += `<div class="star-icon"><img id="favoritePost--${postObj.id}" class="actionIcon" src="../images/favorite-star-blank.svg"></div>`

--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -1,4 +1,4 @@
-import { getPosts, getUsers } from "../data/provider.js"
+import { deleteLike, getLikes, getPosts, getUsers, saveLike } from "../data/provider.js"
 import { PostGif } from "./PostForm.js"
 
 const PostBuilder = (postObj) => {
@@ -10,22 +10,34 @@ const PostBuilder = (postObj) => {
         (user) => {
             return user.id === postObj.userId
         }
-        )
-        let html = ""
-        html += `
+    )
+    let html = ""
+    html += `
         <section class="post">
         <header><h2 class="post__title">${postObj.title}</h2></header>
         <img class="post__image" src="${postObj.url}">
         <section class="post__description">${postObj.description}</section>
         <section class="post__tagline">Posted by ${foundUser.name} on ${dateString}</section>
-        <section class="post__actions">
-        <div class="star-icon"><img id="favoritePost---${postObj.id}" class="actionIcon" src="../images/favorite-star-blank.svg"></div>
-        `
+        <section class="post__actions">`
+
+    //check if postObj.id match a likeObj.postId
+    const likes = getLikes()
+    const foundLike = likes.find(
+        (likeObj) => {
+            return (likeObj.postId === postObj.id)
+        }
+    )
+
+    if (foundLike) {
+        html += `<div class="star-icon"><img id="favoritePost--${postObj.id}" class="actionIcon" src="../images/favorite-star-yellow.svg"></div>`
+    } else {
+        html += `<div class="star-icon"><img id="favoritePost--${postObj.id}" class="actionIcon" src="../images/favorite-star-blank.svg"></div>`
+    }
 
     if (postObj.userId === parseInt(localStorage.getItem("gg_user"))) {
-        html += `<div class="trash-icon"><img id="deletePost---${postObj.id}" class="actionIcon" src="../images/block.svg"></div>`
+        html += `<div class="trash-icon"><img id="deletePost--${postObj.id}" class="actionIcon" src="../images/block.svg"></div>`
     }
-    
+
     html += `</section>
     </section>`
     return html
@@ -39,6 +51,41 @@ export const PostList = () => {
     const postListItems = posts.map(PostBuilder)
     html += postListItems.join("")
     return html
-
 }
 
+
+const mainContainer = document.querySelector(".giffygram")
+
+mainContainer.addEventListener("click", clickEvent => {
+    //check if id starts with
+    if (clickEvent.target.id.startsWith("favoritePost--")) {
+        //split at -- to grab postId
+        const [, postId] = clickEvent.target.id.split("--")
+        const posts = getPosts()
+        const foundPost = posts.find(
+            (postObj) => {
+                return postObj.id === parseInt(postId)
+            }
+        )
+        const likes = getLikes()
+        const foundLike = likes.find(
+            (likeObj) => {
+                return likeObj.postId === foundPost.id && likeObj.userId === parseInt(localStorage.getItem("gg_user"))
+            }
+        )
+
+        if (foundLike) {
+            deleteLike(foundLike.id)
+
+        } else {
+            
+            const likeObj = {
+                userId: foundPost.userId,
+                postId: parseInt(postId)
+            }
+    
+            saveLike(likeObj)
+        }
+
+    }
+})

--- a/src/scripts/nav/NavBar.js
+++ b/src/scripts/nav/NavBar.js
@@ -12,7 +12,7 @@ export const NavBar = () => {
     <div class="navigation__item navigation__search"></div>
 
     <div class="navigator__item navigation__message">
-        <img id="directMessageIcon" src="../images/fountain-pen.svg" alt+'Direct message">
+        <img id="directMessageIcon" src="../images/fountain-pen.svg" alt="Direct message">
         <div class="notification__count">0</div>
     </div>
 


### PR DESCRIPTION
#### Changes Made
1. Event listener to star icon on posts to save or delete like objects
​
#### Related Issue(s)
Fixes #9 
Fixes #54

#### Steps to Review
1. Provided the user is logged in and viewing a list of 1 or more posts in the main feed, the user can click on a star icon under a post and, depending on whether or not there's currently a like object already associated with that user and post, a new like object will be created and the blank star icon will turn yellow OR the associated like object will be deleted from the database and the yellow star icon will turn back to a blank star.
2. Be sure to check the network tab in dev tools that a new like object is being created and the correct like object is being deleted when appropriate.
