### PR TITLE
added event listener to close message form

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -39,3 +39,11 @@ applicationElement.addEventListener(
     }
 )
 
+applicationElement.addEventListener(
+    "closeDirectMessage",
+    customEvent => {
+        messageForm = false
+        applicationElement.dispatchEvent(new CustomEvent("stateChanged"))
+
+    }
+)

--- a/src/scripts/feed/PostForm.js
+++ b/src/scripts/feed/PostForm.js
@@ -48,7 +48,7 @@ mainContainer.addEventListener("click", clickEvent => {
             description: document.querySelector("textarea[name='caption']").value,
             timestamp: Date.now()
         }
-
+     
         savePost(postObj)
     }
 })

--- a/src/scripts/message/MessageForm.js
+++ b/src/scripts/message/MessageForm.js
@@ -29,6 +29,13 @@ mainContainer.addEventListener("click", clickEvent => {
     }
 })
 
+mainContainer.addEventListener("click", clickEvent => {
+if (clickEvent.target.id === "directMessage__close") {
+    mainContainer.dispatchEvent(new CustomEvent("closeDirectMessage"))
+}
+
+})
+
 
 
 export const MessageForm = () => {


### PR DESCRIPTION
#### Changes Made
1. Added custom event listeners to re-render giffygram page without the message form element when the user clicks on the x in the top right corner of the element.
​
#### Related Issue(s)
Supports #1

#### Steps to Review
1. provided the user is logged in and viewing the main posts feed, click on the fountain pen in the nav bar to open up the direct message form.
2. Once the message form has been rendered on the page, click on the x in the top right corner of the element and the page should immediately re-render without the message form on the page.
