### PR TITLE
added event listener to delete post

### DIFF
--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -1,4 +1,4 @@
-import { deleteLike, getLikes, getPosts, getUsers, saveLike } from "../data/provider.js"
+import { deleteLike, deletePost, getLikes, getPosts, getUsers, saveLike } from "../data/provider.js"
 import { PostGif } from "./PostForm.js"
 
 const PostBuilder = (postObj) => {
@@ -86,6 +86,17 @@ mainContainer.addEventListener("click", clickEvent => {
     
             saveLike(likeObj)
         }
+
+    }
+})
+
+mainContainer.addEventListener("click", clickEvent => {
+    //check if id starts with
+    if (clickEvent.target.id.startsWith("deletePost--")) {
+        //split at -- to grab postId
+        const [, postId] = clickEvent.target.id.split("--")
+
+        deletePost(parseInt(postId))
 
     }
 })


### PR DESCRIPTION
#### Changes Made
1. Added event listener to delete icon on each post that delete the post object from the database
​
#### Related Issue(s)
Fixes #51

#### Steps to Review
1. provided the user is logged in and viewing the giffygram post list feed and at least one of the posts in the feed was submitted by the active user, the user can click on the trash can under the post and it will delete that post from the database. The page should then re-render without the post object in the feed.
