### PR TITLE
added if statement to save post event listener

### DIFF
--- a/src/scripts/feed/PostForm.js
+++ b/src/scripts/feed/PostForm.js
@@ -48,8 +48,14 @@ mainContainer.addEventListener("click", clickEvent => {
             description: document.querySelector("textarea[name='caption']").value,
             timestamp: Date.now()
         }
+
+        if (postObj.title && postObj.url && postObj.description) {
+            savePost(postObj)
+        
+        } else {
+            window.alert(`Please fill out all fields completely`)
+        }
      
-        savePost(postObj)
     }
 })
 


### PR DESCRIPTION
#### Changes Made
1. save post event listener now has an if statement that checks that all input fields have value before invoking savePost function. If any fields are left blank it triggers a window alert.
​
#### Related Issue(s)
Fixes #57 
Fixes #12 

#### Steps to Review
1. provided the user is logged in and viewing the posts feed. Click on the "have a gif to post" element to open the post form.
2. leave at least one field empty and click on the post button at the bottom of the form.
3. the post will not be saves and instead a window alert should pop up reminding the user that all fields should be filled out completely.
