### PR TITLE
Post List Feed Can Be Filtered By User

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -1,6 +1,7 @@
 import { PostList } from "./feed/PostList.js"
 import { NavBar } from "./nav/NavBar.js"
 import { MessageForm } from "./message/MessageForm.js"
+import { Footer } from "./nav/Footer.js"
 
 
 
@@ -14,14 +15,14 @@ export const GiffyGram = () => {
         <nav class="navigation">${NavBar()}</nav>
         <section class="empty"></section>
         <section class="giffygram__feed">${PostList()}</section>
-        <footer class="footer>Footer</footer>
+        <footer class="footer">${Footer()}</footer>
         `
     } else {
         return `
         <nav class="navigation">${NavBar()}</nav>
         <section class="directMessage">${MessageForm()}</section>
         <section class="giffygram__feed">${PostList()}</section>
-        <footer class="footer>Footer</footer>
+        <footer class="footer">${Footer()}</footer>
 
         `
     }

--- a/src/scripts/data/provider.js
+++ b/src/scripts/data/provider.js
@@ -163,3 +163,27 @@ export const sendRegistration = (userRegistration) => {
     })
 }
 
+export const getFeed = () => {
+    return applicationState.feed
+}
+
+export const setUserFilter = (id) => {
+    if (id > 0) {
+        applicationState.feed.chosenUser = id
+    } else if (id === 0) {
+        applicationState.feed.chosenUser = null
+    }
+}
+
+export const toggleFavorites = () => {
+    if (applicationState.feed.displayFavorites = false) {
+        applicationState.feed.displayFavorites = true
+    } else {
+        applicationState.feed.displayFavorites = false
+    }
+}
+
+export const setYearFilter = (value) => {
+    applicationState.feed.chosenYear = value
+}
+

--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -44,7 +44,8 @@ const PostBuilder = (postObj) => {
 }
 
 export const PostList = () => {
-    const allPosts = getPosts()
+    const posts = getPosts()
+    const allPosts = posts.reverse()
     const feed = getFeed()
     
     const userSortedPosts = allPosts.filter(

--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -1,4 +1,4 @@
-import { deleteLike, deletePost, getLikes, getPosts, getUsers, saveLike } from "../data/provider.js"
+import { deleteLike, deletePost, getFeed, getLikes, getPosts, getUsers, saveLike } from "../data/provider.js"
 import { PostGif } from "./PostForm.js"
 
 const PostBuilder = (postObj) => {
@@ -44,12 +44,25 @@ const PostBuilder = (postObj) => {
 }
 
 export const PostList = () => {
-    const posts = getPosts()
-    let html = `
-                <section class="miniMod">${PostGif()}</section>`
+    const allPosts = getPosts()
+    const feed = getFeed()
+    
+    const userSortedPosts = allPosts.filter(
+        (post) => {
+            return (post.userId === feed.chosenUser)
+        }
+    )
+    let html = `<section class="miniMod">${PostGif()}</section>`
 
-    const postListItems = posts.map(PostBuilder)
-    html += postListItems.join("")
+    if (feed.chosenUser) {
+        const postListItems = userSortedPosts.map(PostBuilder)
+        html += postListItems.join("")
+    } else {
+
+        const postListItems = allPosts.map(PostBuilder)
+        html += postListItems.join("")
+    }
+
     return html
 }
 

--- a/src/scripts/nav/Footer.js
+++ b/src/scripts/nav/Footer.js
@@ -1,0 +1,36 @@
+import { setUserFilter } from "../data/provider.js"
+import { UserSelect } from "./UserSelect.js"
+
+
+export const Footer = () => {
+    return `
+        <section class="footer__item">
+        Posts Since 
+            <select id="yearSelection"></select>
+            <span id="postCount">8</span>
+        </section>
+        
+        <section class="footer__item">
+        Posts by user 
+            <select id="userSelection">
+            ${UserSelect()}
+            </select>
+        </section>
+
+        <section class="footer__item">
+        Show only favorites 
+            <input id="showOnlyFavorites" type="checkbox">
+        </section>
+
+    `
+}
+
+
+const mainContainer = document.querySelector(".giffygram")
+
+document.addEventListener("change", (event) => {
+    if (event.target.id === "userSelection") {
+        setUserFilter(parseInt(event.target.value)) 
+        mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+    }
+})

--- a/src/scripts/nav/NavBar.js
+++ b/src/scripts/nav/NavBar.js
@@ -29,6 +29,7 @@ mainContainer.addEventListener("click", clickEvent => {
     if (clickEvent.target.id === "logout") {
 
         localStorage.setItem("gg_user", null)
+        mainContainer.dispatchEvent(new CustomEvent("closeDirectMessage"))
         mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
 
     }

--- a/src/scripts/nav/UserSelect.js
+++ b/src/scripts/nav/UserSelect.js
@@ -1,0 +1,20 @@
+import { getFeed, getUsers } from "../data/provider.js";
+
+export const UserSelect = () => {
+    const feedState = getFeed()
+    const users = getUsers()
+    let html = `<option class="user" value="0">All users</option>`
+    
+    users.forEach(
+        (user) => {
+            html += `<option class="user" value="${user.id}"`
+            if (feedState.chosenUser === user.id) {
+                html += ` selected`
+            }
+            html += `>${user.name}</option>`
+        }
+    )
+
+    return html
+}
+


### PR DESCRIPTION
#### Changes Made
1.  Posts lists can now be sorted by user (with their full name)
2. Also adjusted event listener for logout button to make sure the message form does not show up if it was previously left open before previous user logged out.
​
#### Related Issue(s)
Fixes #48 
Fixes #46 
Fixes #5 
Fixes #6 

#### Steps to Review
1.  Provided user is logged in and viewing the posts list in the feed. Select a name in the drop down list in the footer and the list of posts should immediately re-render to only show posts submitted by that user. Clear user selection by selecting the "all users" option in the drop down field.
