### PR TITLE
fixed variable error in event listener for pb icon

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -68,7 +68,7 @@ applicationElement.addEventListener(
 applicationElement.addEventListener(
     "homepage",
     customEvent => {
-        messageForm = false
+        directMessagePage = false
         applicationElement.dispatchEvent(new CustomEvent("stateChanged"))
 
     }


### PR DESCRIPTION
#### Changes Made
1.  Changed variable in giffygram event listener for "homepage" so that it correctly refreshes the page to the post feed every time.
​
#### Related Issue(s)
Fixes #83 

#### Steps to Review
1. When viewing private messages, click on the pb icon in the nav bar and it should replace the direct messages feed with the posts list.
