### PR TITLE
View only favorite posts

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -69,6 +69,7 @@ applicationElement.addEventListener(
     "homepage",
     customEvent => {
         directMessagePage = false
+        messageForm = false
         applicationElement.dispatchEvent(new CustomEvent("stateChanged"))
 
     }

--- a/src/scripts/data/provider.js
+++ b/src/scripts/data/provider.js
@@ -173,17 +173,24 @@ export const setUserFilter = (id) => {
     } else if (id === 0) {
         applicationState.feed.chosenUser = null
     }
+    mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+
 }
 
 export const toggleFavorites = () => {
-    if (applicationState.feed.displayFavorites = false) {
-        applicationState.feed.displayFavorites = true
-    } else {
+
+    if (applicationState.feed.displayFavorites) {
         applicationState.feed.displayFavorites = false
+    } else {
+        applicationState.feed.displayFavorites = true
     }
+    mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+
 }
 
 export const setYearFilter = (value) => {
     applicationState.feed.chosenYear = value
+    mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+
 }
 

--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -44,9 +44,10 @@ const PostBuilder = (postObj) => {
 }
 
 export const PostList = () => {
+    const feed = getFeed()
+
     const posts = getPosts()
     const allPosts = posts.reverse()
-    const feed = getFeed()
     
     const userSortedPosts = allPosts.filter(
         (post) => {
@@ -55,7 +56,27 @@ export const PostList = () => {
     )
     let html = `<section class="miniMod">${PostGif()}</section>`
 
-    if (feed.chosenUser) {
+    const favoritePosts = []
+    
+    allPosts.forEach(
+        (post) => {
+            const likes = getLikes()
+            const foundLike = likes.find(
+            (like) => {
+                return (like.postId ===post.id && like.userId === parseInt(localStorage.getItem("gg_user")))
+                }
+            )
+            if (foundLike) {
+                favoritePosts.push(post)
+
+            }
+        }
+    )
+
+    if (feed.displayFavorites) {
+        const favoriteListItems = favoritePosts.map(PostBuilder)
+        html += favoriteListItems.join("")
+    } else if (feed.chosenUser) {
         const postListItems = userSortedPosts.map(PostBuilder)
         html += postListItems.join("")
     } else {

--- a/src/scripts/nav/Footer.js
+++ b/src/scripts/nav/Footer.js
@@ -1,9 +1,9 @@
-import { setUserFilter } from "../data/provider.js"
+import { getFeed, setUserFilter, toggleFavorites } from "../data/provider.js"
 import { UserSelect } from "./UserSelect.js"
 
 
 export const Footer = () => {
-    return `
+    let html = `
         <section class="footer__item">
         Posts Since 
             <select id="yearSelection"></select>
@@ -19,10 +19,14 @@ export const Footer = () => {
 
         <section class="footer__item">
         Show only favorites 
-            <input id="showOnlyFavorites" type="checkbox">
-        </section>
-
-    `
+            <input id="showOnlyFavorites" type="checkbox"`
+    const feed = getFeed()
+    if (feed.displayFavorites) {
+        html += ` checked></section>`
+    } else {
+        html += `></section>`
+    }
+    return html
 }
 
 
@@ -30,7 +34,14 @@ const mainContainer = document.querySelector(".giffygram")
 
 document.addEventListener("change", (event) => {
     if (event.target.id === "userSelection") {
-        setUserFilter(parseInt(event.target.value)) 
+        setUserFilter(parseInt(event.target.value))
+        mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+    }
+})
+
+document.addEventListener("change", (event) => {
+    if (event.target.id === "showOnlyFavorites") {
+        toggleFavorites()
         mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
     }
 })


### PR DESCRIPTION
#### Changes Made
1.  Added event listener to favorites checkbox in footer that re-renders the page with only favorited posts. Unchecking the box will result in viewing all posts again.
​
#### Related Issue(s)
Fixes #8 
Fixes #49 

#### Steps to Review
1. When viewing the posts list, click on the favorites checkbox in the footer. The page should immediately re-render with only favorited posts. If the current user has not selected any favorites, the posts feed will be empty. Unchecking the box will render all posts.
