### PR TITLE
User can now sort posts by year

### DIFF
--- a/src/scripts/feed/PostList.js
+++ b/src/scripts/feed/PostList.js
@@ -73,13 +73,26 @@ export const PostList = () => {
         }
     )
 
+    const yearSortedPosts = []
+    allPosts.forEach(
+        (post) => {
+            const postYear = new Date(post.timestamp).getFullYear()
+            if(postYear >= feed.chosenYear) {
+                yearSortedPosts.push(post)
+            }
+        }
+    )
+
     if (feed.displayFavorites) {
         const favoriteListItems = favoritePosts.map(PostBuilder)
         html += favoriteListItems.join("")
     } else if (feed.chosenUser) {
-        const postListItems = userSortedPosts.map(PostBuilder)
-        html += postListItems.join("")
-    } else {
+        const userListItems = userSortedPosts.map(PostBuilder)
+        html += userListItems.join("")
+    } else if (feed.chosenYear) {
+        const yearListItems = yearSortedPosts.map(PostBuilder)
+        html += yearListItems.join("")       
+    }else {
 
         const postListItems = allPosts.map(PostBuilder)
         html += postListItems.join("")

--- a/src/scripts/nav/Footer.js
+++ b/src/scripts/nav/Footer.js
@@ -1,12 +1,15 @@
-import { getFeed, setUserFilter, toggleFavorites } from "../data/provider.js"
+import { getFeed, setUserFilter, setYearFilter, toggleFavorites } from "../data/provider.js"
 import { UserSelect } from "./UserSelect.js"
+import { YearSelect } from "./YearSelect.js"
 
 
 export const Footer = () => {
     let html = `
         <section class="footer__item">
         Posts Since 
-            <select id="yearSelection"></select>
+            <select id="yearSelection">
+            ${YearSelect()}
+            </select>
             <span id="postCount">8</span>
         </section>
         
@@ -45,3 +48,11 @@ document.addEventListener("change", (event) => {
         mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
     }
 })
+
+document.addEventListener("change", (event) => {
+    if (event.target.id === "yearSelection") {
+        setYearFilter(parseInt(event.target.value))
+        mainContainer.dispatchEvent(new CustomEvent("stateChanged"))
+    }
+})
+

--- a/src/scripts/nav/YearSelect.js
+++ b/src/scripts/nav/YearSelect.js
@@ -1,0 +1,19 @@
+import { getFeed } from "../data/provider.js";
+
+export const YearSelect = () => {
+    const feedState = getFeed()
+    const years = ["2021", "2020", "2019", "2018", "2017"]
+    let html = `<option class="year" value="0">Forever</option>`
+    
+    years.forEach(
+        (year) => {
+            html += `<option class="year" value="${year}"`
+            if (feedState.chosenYear === parseInt(year)) {
+                html += ` selected`
+            }
+            html += `>${year}</option>`
+        }
+    )
+
+    return html
+}


### PR DESCRIPTION
#### Changes Made
1.  event listener for year select change and modified post list function to sort by year if selected
​
#### Related Issue(s)
Fixes #41 
Fixes #44 

#### Steps to Review
1. when viewing the lists of posts in the feed on the main page, select a year from the dropdown option in the footer. The page should re-render with only post submitted since the selected year.
2. *You may need to alter the timestamps in any currently saved post objects in your database to have at least one option with an earlier timestamps so that it's correctly excluded when selecting a later year.
